### PR TITLE
Expose runBB for caller use

### DIFF
--- a/src/Text/LLVM.hs
+++ b/src/Text/LLVM.hs
@@ -40,6 +40,7 @@ module Text.LLVM (
 
     -- * Basic Blocks
   , BB()
+  , runBB
   , freshLabel
   , label
   , comment


### PR DESCRIPTION
The BB monad is used when generating blocks, and is customarily invoked via the `define` use of `defineBody` in the `DefineArgs` class.  However, there may be cases where the caller needs to wrap the BB monad, which `defineBody` does not support.  This exposes the `runBB` eliminator for the `BB` monad to allow those uses.