### PR TITLE
Support full Data LayoutSpec through LLVM19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,6 @@
 ## 0.14.0.0 (pending)
 
 * Changes to support LLVM 19
-  * Added a list of `GEPOptionalFlag` with values of `GEP_Inline`, `GEP_NUSW`,
-    and `GEP_NUW` to replace the older "inline" `Bool` for `ConstGEP`.  This
-    reflects the corresponding change in LLVM 18 for specifying rules that
-    determine if the result value is poison.  See
-    https://llvm.org/docs/LangRef.html#getelementptr-instruction for more
-    details.
-  * `ConstGEP` range changed from a simple index (`Word64`) to a sum-type
-    `RangeSpec` of `RangeIndex Word64` (to support the original) and `Range Int
-    Integer Integer` to specify the integer precision, followed by the lower
-    bound and upper bounds in that precision.
   * Changes to `LayoutSpec` for DataLayout:
     * Add a `FunctionPointerAlign` constructor to `LayoutSpec`.
     * Size specification fields use a common sub-structure `Storage` which itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
       constructors, each defined via an `AddressSpace` sub-structure.
     * Added `NonIntegralPointerSpaces` to record address spaces with an
       unspecified bitwise representation.
-    * Added `GOFFMangling`, `WindowsX86CoffMangling`, and `XCOFFMangling` forms
+    * Added `GoffMangling`, `WindowsX86CoffMangling`, and `XCoffMangling` forms
       of Mangling.
 
 ## 0.13.0.0 (March 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   * Changes to `LayoutSpec` for DataLayout:
     * Add a `FunctionPointerAlign` constructor to `LayoutSpec`.
     * Size specification fields use a common sub-structure `Storage` which itself
-      contains an `Alignment` common sub-structure.: `IntegerSize`, `VectorSize`,
+      contains an `Alignment` common sub-structure: `IntegerSize`, `VectorSize`,
       `FloatSize`, and `StackObjSize`.
     * The pointer size specification field uses a `PointerSize` sub-structure
       that itself contains a `Storage` sub-structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,34 @@
 # Revision history for llvm-pretty
 
-## pending
+## 0.14.0.0 (pending)
 
-* Add a `FunctionPointerAlign` constructor to `LayoutSpec`.
+* Changes to support LLVM 19
+  * Added a list of `GEPOptionalFlag` with values of `GEP_Inline`, `GEP_NUSW`,
+    and `GEP_NUW` to replace the older "inline" `Bool` for `ConstGEP`.  This
+    reflects the corresponding change in LLVM 18 for specifying rules that
+    determine if the result value is poison.  See
+    https://llvm.org/docs/LangRef.html#getelementptr-instruction for more
+    details.
+  * `ConstGEP` range changed from a simple index (`Word64`) to a sum-type
+    `RangeSpec` of `RangeIndex Word64` (to support the original) and `Range Int
+    Integer Integer` to specify the integer precision, followed by the lower
+    bound and upper bounds in that precision.
+  * Changes to `LayoutSpec` for DataLayout:
+    * Add a `FunctionPointerAlign` constructor to `LayoutSpec`.
+    * Size specification fields use a common sub-structure `Storage` which itself
+      contains an `Alignment` common sub-structure.: `IntegerSize`, `VectorSize`,
+      `FloatSize`, and `StackObjSize`.
+    * The pointer size specification field uses a `PointerSize` sub-structure
+      that itself contains a `Storage` sub-structure.
+    * Updated `AggregateSize` to make first field optional (it was dropped in
+      LLVM 4) and the remaining fields are now provided via the `Alignment`
+      sub-structure.
+    * Added `ProgramAddrSpace`, `GlobalAddrSpace`, and `AllocaAddrSpace`
+      constructors, each defined via an `AddressSpace` sub-structure.
+    * Added `NonIntegralPointerSpaces` to record address spaces with an
+      unspecified bitwise representation.
+    * Added `GOFFMangling`, `WindowsX86CoffMangling`, and `XCOFFMangling` forms
+      of Mangling.
 
 ## 0.13.0.0 (March 2025)
 

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -25,6 +25,7 @@ common common
   Default-language:    Haskell2010
   Ghc-options:
     -Wall
+    -fhide-source-paths
 
 Library
   Import:              common

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       2.2
 Name:                llvm-pretty
-Version:             0.13.0.0.99
+Version:             0.13.0.0.100
 License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Trevor Elliott
@@ -63,6 +63,7 @@ Test-suite llvm-pretty-test
   Type: exitcode-stdio-1.0
   Main-is: Main.hs
   Other-modules:
+    DataLayout
     Output
     Triple
     TQQDefs

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -343,12 +343,12 @@ type AddressSpace = Int
 type NumBits = Int
 
 data Mangling = ElfMangling
-              | GOFFMangling
+              | GoffMangling
               | MipsMangling
               | MachOMangling
               | WindowsCoffMangling
               | WindowsX86CoffMangling
-              | XCOFFMangling
+              | XCoffMangling
                 deriving (Data, Eq, Enum, Generic, Ord, Show, Typeable)
 
 -- | Parse the data layout string.
@@ -420,12 +420,12 @@ parseDataLayout str =
       do c <- letter
          case c of
            'e' -> return ElfMangling
-           'l' -> return GOFFMangling
+           'l' -> return GoffMangling
            'm' -> return MipsMangling
            'o' -> return MachOMangling
            'w' -> return WindowsCoffMangling
            'x' -> return WindowsX86CoffMangling
-           'a' -> return XCOFFMangling
+           'a' -> return XCoffMangling
            _   -> mzero
 
     pAlignment :: Parser Alignment

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -395,14 +395,14 @@ parseDataLayout str =
            's' -> StackObjSize <$> pStorage -- Obsoleted in LLVM4
            'a' -> alphaNum >>= \case
              ':' -> AggregateSize Nothing <$> pAlignment
-             d   -> AggregateSize <$> (Just <$> pInt' d)
+             d   -> AggregateSize <$> (Just <$> pIntWithFirstDigit d)
                     <* char ':' <*> pAlignment
            'F' -> FunctionPointerAlign <$> pFunctionPointerAlignType <*> pInt -- Added in LLVM9
            'm' -> Mangling <$ char ':' <*> pMangling
            'n' -> alphaNum >>= \case
              'i' -> char ':'
                     >> (NonIntegralPointerSpaces <$> sepBy pInt (char ':'))
-             d -> do fs <- pInt' d
+             d -> do fs <- pIntWithFirstDigit d
                      ss <- char ':' *> sepBy pInt (char ':')
                      return $ NativeIntSize $ fs : ss
            _   -> mzero
@@ -437,8 +437,8 @@ parseDataLayout str =
     pInt :: Parser Int
     pInt = read <$> many1 digit
 
-    pInt' :: Char -> Parser Int
-    pInt' d0 = read . (d0:) <$> many digit
+    pIntWithFirstDigit :: Char -> Parser Int
+    pIntWithFirstDigit d0 = read . (d0:) <$> many digit
 
     pCInt :: Parser Int
     pCInt = char ':' >> pInt

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -35,6 +35,8 @@ module Text.LLVM.AST
   , FunctionPointerAlignType(..)
   , Storage(..)
   , PointerSize(..)
+  , AddressSpace
+  , NumBits
   , Mangling(..)
   , parseDataLayout
     -- * Inline Assembly

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -395,7 +395,7 @@ parseDataLayout str =
              ':' -> AggregateSize Nothing <$> pAlignment
              d   -> AggregateSize <$> (Just <$> pInt' d)
                     <* char ':' <*> pAlignment
-           'F' -> FunctionPointerAlign <$> pFunctionPointerAlignType <*> pInt
+           'F' -> FunctionPointerAlign <$> pFunctionPointerAlignType <*> pInt -- Added in LLVM9
            'm' -> Mangling <$ char ':' <*> pMangling
            'n' -> alphaNum >>= \case
              'i' -> char ':'

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -253,12 +253,12 @@ ppFunctionPointerAlignType ty =
 
 ppMangling :: Fmt Mangling
 ppMangling ElfMangling         = char 'e'
-ppMangling GOFFMangling        = char 'l'
+ppMangling GoffMangling        = char 'l'
 ppMangling MipsMangling        = char 'm'
 ppMangling MachOMangling       = char 'o'
 ppMangling WindowsCoffMangling = char 'w'
 ppMangling WindowsX86CoffMangling = char 'x'
-ppMangling XCOFFMangling       = char 'a'
+ppMangling XCoffMangling       = char 'a'
 
 
 -- Inline Assembly -------------------------------------------------------------

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -206,28 +206,44 @@ ppLayoutSpec ls =
   case ls of
     BigEndian                 -> char 'E'
     LittleEndian              -> char 'e'
-    PointerSize 0 sz abi pref -> char 'p' <> char ':' <> ppLayoutBody sz abi pref
-    PointerSize n sz abi pref -> char 'p' <> int n <> char ':'
-                                          <> ppLayoutBody sz abi pref
-    IntegerSize   sz abi pref -> char 'i' <> ppLayoutBody sz abi pref
-    VectorSize    sz abi pref -> char 'v' <> ppLayoutBody sz abi pref
-    FloatSize     sz abi pref -> char 'f' <> ppLayoutBody sz abi pref
-    StackObjSize  sz abi pref -> char 's' <> ppLayoutBody sz abi pref
-    AggregateSize sz abi pref -> char 'a' <> ppLayoutBody sz abi pref
+    PointerSize ps            -> char 'p' <> ppPointerSize ps
+    IntegerSize sz            -> char 'i' <> ppStorage sz
+    VectorSize  sz            -> char 'v' <> ppStorage sz
+    FloatSize   sz            -> char 'f' <> ppStorage sz
+    StackObjSize sz           -> char 's' <> ppStorage sz
+    AggregateSize Nothing a   -> char 'a' <> char ':' <> ppAlignment a
+    AggregateSize (Just s) a  -> char 'a' <> int s <> char ':' <> ppAlignment a
     NativeIntSize szs         ->
       char 'n' <> hcat (punctuate (char ':') (map int szs))
+    StackAlign a              -> char 'S' <> int a
+    ProgramAddrSpace as       -> char 'P' <> int as
+    GlobalAddrSpace as        -> char 'G' <> int as
+    AllocaAddrSpace as        -> char 'A' <> int as
     FunctionPointerAlign ty abi ->
       char 'F' <> ppFunctionPointerAlignType ty <> int abi
-    StackAlign a              -> char 'S' <> int a
     Mangling m                -> char 'm' <> char ':' <> ppMangling m
+    NonIntegralPointerSpaces asl ->
+      "ni:" <> hcat (punctuate (char ':') (map int asl))
 
--- | Pretty-print the common case for data layout specifications.
-ppLayoutBody :: Int -> Int -> Fmt (Maybe Int)
-ppLayoutBody size abi mb = int size <> char ':' <> int abi <> pref
-  where
-  pref = case mb of
-    Nothing -> empty
-    Just p  -> char ':' <> int p
+ppPointerSize :: Fmt PointerSize
+ppPointerSize ps =
+  if ptrAddrSpace ps == 0
+  then char ':' <> ppStorage (ptrStorage ps)
+       <> ppOptColonInt (ptrAddrIndexSize ps)
+  else int (ptrAddrSpace ps) <> char ':' <> ppStorage (ptrStorage ps)
+       <> ppOptColonInt (ptrAddrIndexSize ps)
+
+ppStorage :: Fmt Storage
+ppStorage s = int (storageSize s) <> char ':'
+              <> ppAlignment (storageAlignment s)
+
+ppAlignment :: Fmt Alignment
+ppAlignment a = int (alignABI a) <> ppOptColonInt (alignPreferred a)
+
+ppOptColonInt :: Fmt (Maybe Int)
+ppOptColonInt = \case
+  Nothing -> empty
+  Just i  -> char ':' <> int i
 
 ppFunctionPointerAlignType :: Fmt FunctionPointerAlignType
 ppFunctionPointerAlignType ty =
@@ -237,9 +253,12 @@ ppFunctionPointerAlignType ty =
 
 ppMangling :: Fmt Mangling
 ppMangling ElfMangling         = char 'e'
+ppMangling GOFFMangling        = char 'l'
 ppMangling MipsMangling        = char 'm'
 ppMangling MachOMangling       = char 'o'
 ppMangling WindowsCoffMangling = char 'w'
+ppMangling WindowsX86CoffMangling = char 'x'
+ppMangling XCOFFMangling       = char 'a'
 
 
 -- Inline Assembly -------------------------------------------------------------

--- a/test/DataLayout.hs
+++ b/test/DataLayout.hs
@@ -1,0 +1,31 @@
+module DataLayout ( tests ) where
+
+import Text.LLVM.AST
+import Text.LLVM.PP
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  let rspDL s = Just $ "target datalayout = \"" <> s <> "\""
+      ppDL = show . ppLLVM llvmVlatest ppDataLayout
+  in testGroup "Test DataLayout"
+     [ testCase "datalayout 0" $ ppDL <$> (parseDataLayout "") @?= Just ""
+     , testCase "datalayout 1"
+       $ let dl = "e" in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+     , testCase "datalayout 2"
+       $ let dl = "e-m:e" in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+     , testCase "datalayout 3"
+       $ let dl = "e-m:e-p270:32:32"
+         in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+     , testCase "datalayout 4"
+       $ let dl = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-S128"
+         in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+     , testCase "datalayout 5"
+       $ let dl = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+         in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+     , testCase "datalayout 6"
+       $ let dl = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-ni:3:4-S128"
+         in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+     ]

--- a/test/DataLayout.hs
+++ b/test/DataLayout.hs
@@ -11,21 +11,21 @@ tests =
   let rspDL s = Just $ "target datalayout = \"" <> s <> "\""
       ppDL = show . ppLLVM llvmVlatest ppDataLayout
   in testGroup "Test DataLayout"
-     [ testCase "datalayout 0" $ ppDL <$> (parseDataLayout "") @?= Just ""
+     [ testCase "datalayout 0" $ ppDL <$> parseDataLayout "" @?= Just ""
      , testCase "datalayout 1"
-       $ let dl = "e" in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+       $ let dl = "e" in ppDL <$> parseDataLayout dl @?= rspDL dl
      , testCase "datalayout 2"
-       $ let dl = "e-m:e" in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+       $ let dl = "e-m:e" in ppDL <$> parseDataLayout dl @?= rspDL dl
      , testCase "datalayout 3"
        $ let dl = "e-m:e-p270:32:32"
-         in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+         in ppDL <$> parseDataLayout dl @?= rspDL dl
      , testCase "datalayout 4"
        $ let dl = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-S128"
-         in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+         in ppDL <$> parseDataLayout dl @?= rspDL dl
      , testCase "datalayout 5"
        $ let dl = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-         in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+         in ppDL <$> parseDataLayout dl @?= rspDL dl
      , testCase "datalayout 6"
        $ let dl = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-ni:3:4-S128"
-         in ppDL <$> (parseDataLayout dl) @?= rspDL dl
+         in ppDL <$> parseDataLayout dl @?= rspDL dl
      ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,10 +4,12 @@ import qualified Test.Tasty as Tasty
 
 import qualified Triple
 import qualified Output
+import qualified DataLayout
 
 main :: IO ()
 main = Tasty.defaultMain $ Tasty.testGroup "LLVM tests"
        [
          Output.tests
        , Triple.tests
+       , DataLayout.tests
        ]


### PR DESCRIPTION
The `LayoutSpec` was not up-to-date and had some inconsistencies that were found examining various bitcode files.  These changes make the `LayoutSpec` parsing current through LLVM 19.

These changes are *not* backward compatible; downstream packages may need updates.