### PR TITLE
Use UnnamedMdIdx newtype wrapper for Unnamed metadata indices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for llvm-pretty
 
-## next
+## next (MAJOR)
 
 * Support LLVM 22:
   * `DICompileUnit'` now has an additional `dicuSourceLanguageVersion :: Word64`
@@ -26,6 +26,9 @@
 * Added the `ppModuleAtLine` which can be used to pretty-print only the portion
   of the bitcode that is associated with a specific source file and line number
   (this uses the new `atFileLines` function internally).
+
+* Breaking change: Unnamed metadata indexes are in an `UnnamedMdIdx` newtype
+  wrapper now instead of being an undecorated `Int`.
 
 ## 0.14.0.0 -- 2026-01-23
 

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,6 +1,7 @@
 Cabal-version:       2.2
 Name:                llvm-pretty
-Version:             0.14.0.0.99
+Version:             0.14.0.0.100
+                     -- TODO: needs to be 0.15 due to UnnamedMdIdx newtype wrapper
 License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Trevor Elliott

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -287,18 +287,18 @@ data NamedMd = NamedMd
 
 -- Unnamed Metadata ------------------------------------------------------------
 
--- | This is the type used to represent an Unnamed Metadata index.  A newtype
+-- | This is the type used to represent an unnamed metadata index.  A newtype
 -- wrapper is used to distinguish the specific use of this value as this
 -- particular type of index.
 --
 -- The Ord instance is provided to allow these indices to be used as Map keys.
--- Although Num and Enum are provided to enable manipulation, care should be
--- taken that these are all very carefully used only where needed and
--- appropriate.  In general, the `nextUnnamedMdIdx` is preferred.
+-- Although Num and Enum instances are provided to enable manipulation, care
+-- should be taken that these are all very carefully used only where needed and
+-- appropriate.  In general, the `nextUnnamedMdIdx` function is preferred.
 newtype UnnamedMdIdx = UnnamedMdIdx { unnamedMdIdx :: Int }
   deriving (Data, Eq, Generic, Ord, Enum, Num, Show)
 
--- | This is used when constructing an AST and a new Unnamed Metadata element is
+-- | This is used when constructing an AST and a new unnamed metadata element is
 -- to be added.  It should be passed the current maximum known index and will
 -- return the new, unused index that should be used.
 nextUnnamedMdIdx :: UnnamedMdIdx -> UnnamedMdIdx

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -287,9 +287,20 @@ data NamedMd = NamedMd
 
 -- Unnamed Metadata ------------------------------------------------------------
 
+-- | This is the type used to represent an Unnamed Metadata index.  A newtype
+-- wrapper is used to distinguish the specific use of this value as this
+-- particular type of index.
+--
+-- The Ord instance is provided to allow these indices to be used as Map keys.
+-- Although Num and Enum are provided to enable manipulation, care should be
+-- taken that these are all very carefully used only where needed and
+-- appropriate.  In general, the `nextUnnamedMdIdx` is preferred.
 newtype UnnamedMdIdx = UnnamedMdIdx { unnamedMdIdx :: Int }
   deriving (Data, Eq, Generic, Ord, Enum, Num, Show)
 
+-- | This is used when constructing an AST and a new Unnamed Metadata element is
+-- to be added.  It should be passed the current maximum known index and will
+-- return the new, unused index that should be used.
 nextUnnamedMdIdx :: UnnamedMdIdx -> UnnamedMdIdx
 nextUnnamedMdIdx (UnnamedMdIdx i) = UnnamedMdIdx $ i + 1
 
@@ -301,8 +312,9 @@ nextUnnamedMdIdx (UnnamedMdIdx i) = UnnamedMdIdx $ i + 1
 --
 -- Note that it is NOT valid to call this twice (or not at all in the event you
 -- are starting with an optional form).
-nonNullUnnamedMdIdx :: UnnamedMdIdx -> UnnamedMdIdx
-nonNullUnnamedMdIdx (UnnamedMdIdx i) = UnnamedMdIdx $ i - 1
+nonNullUnnamedMdIdx :: UnnamedMdIdx -> Maybe UnnamedMdIdx
+nonNullUnnamedMdIdx (UnnamedMdIdx i) =
+  if i == 0 then Nothing else Just $ UnnamedMdIdx $ i - 1
 
 data UnnamedMd = UnnamedMd
   { umIndex    :: !UnnamedMdIdx

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -10,6 +10,7 @@ incomplete: there are some values that new LLVM versions would accept but are
 not yet represented here.
 -}
 
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric #-}
@@ -25,7 +26,9 @@ module Text.LLVM.AST
     -- * Named Metadata
   , NamedMd(..)
     -- * Unnamed Metadata
-  , UnnamedMd(..)
+  , UnnamedMd(..), UnnamedMdIdx(UnnamedMdIdx, unnamedMdIdx)
+  , nonNullUnnamedMdIdx
+  , nextUnnamedMdIdx
     -- * Aliases
   , GlobalAlias(..)
     -- * Data Layout
@@ -278,14 +281,31 @@ emptyModule  = Module
 
 data NamedMd = NamedMd
   { nmName   :: String
-  , nmValues :: [Int]
+  , nmValues :: [UnnamedMdIdx]
   } deriving (Data, Eq, Generic, Ord, Show)
 
 
 -- Unnamed Metadata ------------------------------------------------------------
 
+newtype UnnamedMdIdx = UnnamedMdIdx { unnamedMdIdx :: Int }
+  deriving (Data, Eq, Generic, Ord, Enum, Num, Show)
+
+nextUnnamedMdIdx :: UnnamedMdIdx -> UnnamedMdIdx
+nextUnnamedMdIdx (UnnamedMdIdx i) = UnnamedMdIdx $ i + 1
+
+-- | In the bitcode, an "optional" unnamed metadata index is indicated by 0 (not
+-- present) or the actual index + 1.  The parsing should treat these optional as
+-- a different type than an UnnamedMdIdx, but this is not presently detected at
+-- the parsing level, so this function is used to convert a parsed UnnamedMdIdx
+-- to the option of the correct index.
+--
+-- Note that it is NOT valid to call this twice (or not at all in the event you
+-- are starting with an optional form).
+nonNullUnnamedMdIdx :: UnnamedMdIdx -> UnnamedMdIdx
+nonNullUnnamedMdIdx (UnnamedMdIdx i) = UnnamedMdIdx $ i - 1
+
 data UnnamedMd = UnnamedMd
-  { umIndex    :: !Int
+  { umIndex    :: !UnnamedMdIdx
   , umValues   :: ValMd
   , umDistinct :: Bool
   } deriving (Data, Eq, Generic, Ord, Show)
@@ -1626,7 +1646,7 @@ data FP128_PPCValue = FP128_PPC_DoubleDouble Double Double
 data ValMd' lab
   = ValMdString String
   | ValMdValue (Typed (Value' lab))
-  | ValMdRef Int
+  | ValMdRef UnnamedMdIdx
   | ValMdNode [Maybe (ValMd' lab)]
   | ValMdLoc (DebugLoc' lab)
   | ValMdDebugInfo (DebugInfo' lab)

--- a/src/Text/LLVM/DebugUtils.hs
+++ b/src/Text/LLVM/DebugUtils.hs
@@ -172,12 +172,14 @@ data UnionFieldInfo = UnionFieldInfo
 
 -- | Compute an 'IntMap' of the unnamed metadata in a module
 mkMdMap :: Module -> IntMap ValMd
-mkMdMap m = IntMap.fromList [ (umIndex md, umValues md) | md <- modUnnamedMd m ]
+mkMdMap m = IntMap.fromList [ (unnamedMdIdx $ umIndex md, umValues md)
+                            | md <- modUnnamedMd m ]
 
 ------------------------------------------------------------------------
 
 getDebugInfo :: MdMap -> ValMd -> Maybe DebugInfo
-getDebugInfo mdMap (ValMdRef i)    = getDebugInfo mdMap =<< IntMap.lookup i mdMap
+getDebugInfo mdMap (ValMdRef (UnnamedMdIdx i)) =
+  getDebugInfo mdMap =<< IntMap.lookup i mdMap
 getDebugInfo _ (ValMdDebugInfo di) = Just di
 getDebugInfo _ _                   = Nothing
 
@@ -186,7 +188,7 @@ getMDFile mdMap = \case
   ValMdDebugInfo (DebugInfoFile i) -> pure $ difDirectory i </> difFilename i
   --  ^^ found it! ^^ or else vvv keep looking (recursively) vvv
   ValMdLoc l -> getMDFile mdMap $ dlScope l
-  ValMdRef i -> mdMap ^. at i . _Just . to (getMDFile mdMap)
+  ValMdRef i -> mdMap ^. at (unnamedMdIdx i) . _Just . to (getMDFile mdMap)
   ValMdDebugInfo (DebugInfoGlobalVariable gv) ->
     (getMDFile mdMap =<< digvFile gv) <|> (getMDFile mdMap =<< digvScope gv)
   ValMdDebugInfo (DebugInfoLocalVariable lv) ->
@@ -208,12 +210,12 @@ getMDFile mdMap = \case
   _ -> Nothing
 
 getInteger :: MdMap -> ValMd -> Maybe Integer
-getInteger mdMap (ValMdRef i)                          = getInteger mdMap =<< IntMap.lookup i mdMap
+getInteger mdMap (ValMdRef (UnnamedMdIdx i))           = getInteger mdMap =<< IntMap.lookup i mdMap
 getInteger _     (ValMdValue (Typed _ (ValInteger i))) = Just i
 getInteger _     _                                     = Nothing
 
 getList :: MdMap -> ValMd -> Maybe [Maybe ValMd]
-getList mdMap (ValMdRef i) = getList mdMap =<< IntMap.lookup i mdMap
+getList mdMap (ValMdRef (UnnamedMdIdx i)) = getList mdMap =<< IntMap.lookup i mdMap
 getList _ (ValMdNode di)   = Just di
 getList _ _                = Nothing
 
@@ -497,7 +499,7 @@ debugInfoArgNames m d =
     Just (ValMdRef s) -> scopeArgs s
     _ -> IntMap.empty
   where
-    scopeArgs :: Int -> IntMap String
+    scopeArgs :: UnnamedMdIdx -> IntMap String
     scopeArgs s = IntMap.fromList . mapMaybe go $ modUnnamedMd m
       where
         go :: UnnamedMd -> Maybe (Int, String)
@@ -579,7 +581,7 @@ atFileLines handle seed file line mdule =
               ValMdDebugInfo (DebugInfoCompositeType x) -> dictLine x
               ValMdDebugInfo (DebugInfoNameSpace x) -> dinsLine x
               ValMdDebugInfo (DebugInfoLabel x) -> dilLine x
-              ValMdRef i -> maybe 0 getMDLine $ mdMap ^. at i
+              ValMdRef (UnnamedMdIdx i) -> maybe 0 getMDLine $ mdMap ^. at i
               _ -> 0
         in and [ maybe False matchesFile (getMDFile mdMap di)
                , line == (toInteger $ getMDLine di)

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -309,11 +309,11 @@ ppSourceName (Just sn) = "source_filename" <+> char '=' <+> doubleQuotes (text s
 ppNamedMd :: Fmt NamedMd
 ppNamedMd nm =
   sep [ ppMetadata (text (nmName nm)) <+> char '='
-      , ppMetadata (braces (commas (map (ppMetadata . int) (nmValues nm)))) ]
+      , ppMetadata (braces (commas (map (ppMetadata . int . unnamedMdIdx) (nmValues nm)))) ]
 
 ppUnnamedMd :: Fmt UnnamedMd
 ppUnnamedMd um =
-  sep [ ppMetadata (int (umIndex um)) <+> char '='
+  sep [ ppMetadata (int (unnamedMdIdx $ umIndex um)) <+> char '='
       , distinct <+> ppValMd (umValues um) ]
   where
   distinct | umDistinct um = "distinct"
@@ -1150,7 +1150,7 @@ ppValMd' :: Fmt i -> Fmt (ValMd' i)
 ppValMd' pp m = case m of
   ValMdString str   -> ppMetadata (ppStringLiteral str)
   ValMdValue tv     -> ppTyped (ppValue' pp) tv
-  ValMdRef i        -> ppMetadata (int i)
+  ValMdRef i        -> ppMetadata (int $ unnamedMdIdx i)
   ValMdNode vs      -> ppMetadataNode' pp vs
   ValMdLoc l        -> ppDebugLoc' pp l
   ValMdDebugInfo di -> ppDebugInfo' pp di


### PR DESCRIPTION
This makes them distinct and explicit.