### PR TITLE
Export Fmt from PP and add class for pretty printing lab parameter

### DIFF
--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -57,7 +57,7 @@ module Text.LLVM.PP
   , ppFunAttr
   , ppLabelDef
   , ppLabel
-  , LabelPrinter(labelPrinter)
+  , PrettyLabel(ppLabel')
   , ppBasicBlock
   , ppStmt
   , ppAttachedMetadata
@@ -629,31 +629,32 @@ ppBasicBlock bb = ppMaybe ppLabelDef (bbLabel bb)
               $+$ nest 2 (vcat (map ppStmt (bbStmts bb)))
 
 
--- | Most of the pretty printing functions in this module are written for the
--- parameterized label data form and thus take a Fmt argument for handling the
--- parameterized label type.
+-- | Most of the pretty printing functions (based on 'Pretty') in this module are
+-- written for the parameterized label data form and thus take a 'Fmt' argument
+-- for handling the parameterized label type.
 --
--- When the parameterized label type is known to be 'BlockLabel', then ppLabel
+-- When the parameterized label type is known to be 'BlockLabel', then 'ppLabel'
 -- can be passed as this first argument to those pretty printing functions.
 --
 -- When the parameterized label type is not known (e.g. when implementing other
--- libraries that utilize llvm-pretty), the library may need to invoke the pretty
--- printer without passing an explicit label printer, and can instead use the
--- following class as a constraint for an instance that will be resolved later.
+-- libraries that utilize @llvm-pretty@), the library may need to invoke the
+-- pretty printer without passing an explicit label printer, and can instead use
+-- the following class as a constraint for an instance that will be resolved
+-- later.
 --
 -- For example:
 --
 -- > data Something lab = Something { ..., val :: Value' lab, ... }
 -- >
--- > instance LabelPrinter lab => Pretty Something where
--- >   pretty s = .... <> ppValue' astLabelPrinter <>
+-- > instance PrettyLabel lab => Pretty Something where
+-- >   pretty s = .... <> ppValue' ppLabel' <>
 --
 
-class LabelPrinter lab where
-  labelPrinter :: Fmt lab
+class PrettyLabel lab where
+  ppLabel' :: Fmt lab
 
-instance LabelPrinter BlockLabel where
-  labelPrinter = ppLabel
+instance PrettyLabel BlockLabel where
+  ppLabel' = ppLabel
 
 
 -- Statements ------------------------------------------------------------------

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -20,6 +20,7 @@
 module Text.LLVM.PP
   (
     Config(Config, cfgVer), withConfig
+  , Fmt
   , LLVMVer, llvmVer, llvmVerToString
   , llvmVlatest, llvmV3_5, llvmV3_6, llvmV3_7, llvmV3_8
   , ppLLVM, ppLLVM35, ppLLVM36, ppLLVM37, ppLLVM38
@@ -56,6 +57,7 @@ module Text.LLVM.PP
   , ppFunAttr
   , ppLabelDef
   , ppLabel
+  , LabelPrinter(labelPrinter)
   , ppBasicBlock
   , ppStmt
   , ppAttachedMetadata
@@ -625,6 +627,33 @@ ppLabel (Anon i)  = char '%' <> int i
 ppBasicBlock :: Fmt BasicBlock
 ppBasicBlock bb = ppMaybe ppLabelDef (bbLabel bb)
               $+$ nest 2 (vcat (map ppStmt (bbStmts bb)))
+
+
+-- | Most of the pretty printing functions in this module are written for the
+-- parameterized label data form and thus take a Fmt argument for handling the
+-- parameterized label type.
+--
+-- When the parameterized label type is known to be 'BlockLabel', then ppLabel
+-- can be passed as this first argument to those pretty printing functions.
+--
+-- When the parameterized label type is not known (e.g. when implementing other
+-- libraries that utilize llvm-pretty), the library may need to invoke the pretty
+-- printer without passing an explicit label printer, and can instead use the
+-- following class as a constraint for an instance that will be resolved later.
+--
+-- For example:
+--
+-- > data Something lab = Something { ..., val :: Value' lab, ... }
+-- >
+-- > instance LabelPrinter lab => Pretty Something where
+-- >   pretty s = .... <> ppValue' astLabelPrinter <>
+--
+
+class LabelPrinter lab where
+  labelPrinter :: Fmt lab
+
+instance LabelPrinter BlockLabel where
+  labelPrinter = ppLabel
 
 
 -- Statements ------------------------------------------------------------------


### PR DESCRIPTION
The recently added explicit export controls for the LLVM pretty printer excluded the `Fmt` definition which is needed externally by some projects.

This also adds a `LabelPrinter` class which allows client code to keep the `lab` type parameter as a type variable yet still invoke the pretty printing.