### PR TITLE
Adds DISubrangeType (LLVM 21).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
     field.
   * `DIBasicType'` now has an additional `dibtDataSize :: Word32` field.
 
+* Support LLVM 21:
+  * Added support for the `DISubrangeType` metadata.
+
 * Corrected the printing of non-normal single-precision floating point
   constants.
 

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1946,19 +1946,19 @@ data DIBasicType' lab = DIBasicType
 
 type DIBasicType = DIBasicType' BlockLabel
 
-data DISubrangeType' lab = DISubrangeType -- Added in LLVM 22
+data DISubrangeType' lab = DISubrangeType -- Added in LLVM 21
   { disrtName       :: Maybe String
   , disrtFile       :: Maybe (ValMd' lab)
   , disrtLine       :: Word32
   , disrtScope      :: Maybe (ValMd' lab)
   , disrtBaseType   :: Maybe (ValMd' lab) -- ^ a type
-  , disrtSize       :: Maybe (ValMd' lab) -- ^ in bits. signed constant, DIVariable, or DIExpression
+  , disrtSize       :: Maybe (ValMd' lab) -- ^ in bits. signed constant, DIVariable, DIGlobalVariable, or DIExpression
   , disrtAlign      :: Word64 -- ^ in bits
   , disrtFlags      :: DIFlags
-  , disrtLowerBound :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, or DIExpression
-  , disrtUpperBound :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, or DIExpression
-  , disrtStride     :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, or DIExpression
-  , disrtBias       :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, or DIExpression
+  , disrtLowerBound :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, DIGlobalVariable, or DIExpression
+  , disrtUpperBound :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, DIGlobalVariable, or DIExpression
+  , disrtStride     :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, DIGlobalVariable, or DIExpression
+  , disrtBias       :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, DIGlobalVariable, or DIExpression
   } deriving (Data, Eq, Functor, Generic, Ord, Show)
 
 type DISubrangeType = DISubrangeType' BlockLabel

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -179,6 +179,7 @@ module Text.LLVM.AST
   , DILocalVariable'(..), DILocalVariable
   , DISubprogram'(..), DISubprogram
   , DISubrange'(..), DISubrange
+  , DISubrangeType'(..), DISubrangeType
   , DISubroutineType'(..), DISubroutineType
   , DIArgList'(..), DIArgList
   , dwarf_DW_APPLE_ENUM_KIND_invalid
@@ -1860,6 +1861,7 @@ data DebugInfo' lab
   | DebugInfoLabel (DILabel' lab)
   | DebugInfoArgList (DIArgList' lab)
   | DebugInfoAssignID -- ^ Introduced in LLVM 17.
+  | DebugInfoSubrangeType (DISubrangeType' lab)
     deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show)
 
 type DebugInfo = DebugInfo' BlockLabel
@@ -1943,6 +1945,23 @@ data DIBasicType' lab = DIBasicType
   } deriving (Data, Eq, Functor, Generic, Ord, Show)
 
 type DIBasicType = DIBasicType' BlockLabel
+
+data DISubrangeType' lab = DISubrangeType -- Added in LLVM 22
+  { disrtName       :: Maybe String
+  , disrtFile       :: Maybe (ValMd' lab)
+  , disrtLine       :: Word32
+  , disrtScope      :: Maybe (ValMd' lab)
+  , disrtBaseType   :: Maybe (ValMd' lab) -- ^ a type
+  , disrtSize       :: Maybe (ValMd' lab) -- ^ in bits. signed constant, DIVariable, or DIExpression
+  , disrtAlign      :: Word64 -- ^ in bits
+  , disrtFlags      :: DIFlags
+  , disrtLowerBound :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, or DIExpression
+  , disrtUpperBound :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, or DIExpression
+  , disrtStride     :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, or DIExpression
+  , disrtBias       :: Maybe (ValMd' lab) -- ^ signed constant, DIVariable, or DIExpression
+  } deriving (Data, Eq, Functor, Generic, Ord, Show)
+
+type DISubrangeType = DISubrangeType' BlockLabel
 
 data DICompileUnit' lab = DICompileUnit
   { dicuLanguage           :: DwarfLang

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -136,6 +136,7 @@ instance HasLabel DILabel'                    where relabel = $(generateRelabel 
 instance HasLabel DebugLoc'                   where relabel = $(generateRelabel 'relabel ''DebugLoc')
 instance HasLabel DebugInfo'                  where relabel = $(generateRelabel 'relabel ''DebugInfo')
 instance HasLabel DIBasicType'                where relabel = $(generateRelabel 'relabel ''DIBasicType')
+instance HasLabel DISubrangeType'             where relabel = $(generateRelabel 'relabel ''DISubrangeType')
 instance HasLabel DIDerivedType'              where relabel = $(generateRelabel 'relabel ''DIDerivedType')
 instance HasLabel DISubroutineType'           where relabel = $(generateRelabel 'relabel ''DISubroutineType')
 instance HasLabel DISubrange'                 where relabel = $(generateRelabel 'relabel ''DISubrange')

--- a/src/Text/LLVM/Lens.hs
+++ b/src/Text/LLVM/Lens.hs
@@ -32,6 +32,7 @@ concat <$> mapM (makeLensesWith (lensRules & lensField .~ (\_ _ n -> [TopName $ 
     , ''DIFile
     , ''DISubrange'
     , ''DIBasicType'
+    , ''DISubrangeType'
     , ''DIExpression
     , ''DISubprogram'
     , ''DISubroutineType'

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -126,6 +126,8 @@ module Text.LLVM.PP
   , ppDITemplateValueParameter'
   , ppDITemplateValueParameter
   , ppDIBasicType'
+  , ppDISubrangeType'
+  , ppDISubrangeType
   , ppDICompileUnit'
   , ppDICompileUnit
   , ppFlags
@@ -172,7 +174,7 @@ import Text.LLVM.Triple.AST (TargetTriple)
 import Text.LLVM.Triple.Print (printTriple)
 
 import Control.Applicative ((<|>))
-import Data.Bits ( shiftL, shiftR, (.|.), (.&.) )
+import Data.Bits ( shiftL, shiftR, (.|.), (.&.), complement, testBit )
 import Data.Bool ( bool )
 import Data.Char (isAlphaNum,isAscii,isDigit,isPrint,ord,toUpper)
 import Data.List ( intersperse, nub )
@@ -182,7 +184,7 @@ import GHC.Float (castDoubleToWord64, castWord32ToFloat, float2Double)
 import Numeric (showHex)
 import Text.PrettyPrint.HughesPJ
 import Data.Int
-import Data.Word (Word16, Word32)
+import Data.Word (Word16, Word32, Word64)
 import Prelude hiding ((<>))
 
 
@@ -1346,6 +1348,7 @@ ppDebugInfo' pp di = case di of
   DebugInfoLocalVariable lv     -> ppDILocalVariable' pp lv
   DebugInfoSubprogram sp        -> ppDISubprogram' pp sp
   DebugInfoSubrange sr          -> ppDISubrange' pp sr
+  DebugInfoSubrangeType srt     -> ppDISubrangeType' pp srt
   DebugInfoSubroutineType st    -> ppDISubroutineType' pp st
   DebugInfoNameSpace ns         -> ppDINameSpace' pp ns
   DebugInfoTemplateTypeParameter dttp  -> ppDITemplateTypeParameter' pp dttp
@@ -1502,6 +1505,26 @@ ppDIBasicType' pp bt = "!DIBasicType"
          else Nothing
        ]
        )
+
+ppDISubrangeType' :: Fmt i -> Fmt (DISubrangeType' i)
+ppDISubrangeType' pp srt = "!DISubrangeType"
+  <> parens (mcommas
+       [     (("name:"     <+>) . doubleQuotes . text) <$> (disrtName srt)
+       ,     (("file:"     <+>) . ppValMd' pp) <$> (disrtFile srt)
+       , pure ("line:"     <+> integral (disrtLine srt))
+       ,     (("scope:"    <+>) . ppValMd' pp) <$> (disrtScope srt)
+       ,     (("size:"     <+>) . ppValMd' pp) <$> (disrtSize srt)
+       , pure ("align:"    <+> integral (disrtAlign srt))
+       , pure ("flags:"    <+> integral (disrtFlags srt))
+       ,     (("baseType:" <+>) . ppValMd' pp) <$> (disrtBaseType srt)
+       , (("lowerBound:"   <+>) . ppInt64ValMd' True pp) <$> disrtLowerBound srt
+       , (("upperBound:"   <+>) . ppInt64ValMd' True pp) <$> disrtUpperBound srt
+       , (("stride:"       <+>) . ppInt64ValMd' True pp) <$> disrtStride srt
+       , (("bias:"         <+>) . ppInt64ValMd' True pp) <$> disrtBias srt
+       ])
+
+ppDISubrangeType :: Fmt DISubrangeType
+ppDISubrangeType = ppDISubrangeType' ppLabel
 
 ppDICompileUnit' :: Fmt i -> Fmt (DICompileUnit' i)
 ppDICompileUnit' pp cu = "!DICompileUnit"
@@ -1859,7 +1882,16 @@ ppInt64ValMd' canFallBack pp = go
           ValMdValue tv
             | PrimType (Integer _) <- typedType tv
             , ValInteger i <- typedValue tv
-              -> integer i  -- 64 bits is the largest Int, so no conversion needed
+              ->
+                -- 64 bits is the largest Int, so no conversion needed.  However,
+                -- we intend to be compatible with LLVM's own tooling, and the
+                -- latter will parse these values as signed and will therefore
+                -- fail to parse a value with the high bit set.  Therefore this
+                -- must emit a signed value as well.
+                let v = fromInteger i :: Word64
+                in if testBit v 63
+                   then char '-' <> integer (toInteger $ complement v + 1)
+                   else integer i
           o@(ValMdDebugInfo (DebugInfoGlobalVariable gv)) ->
             case digvVariable gv of
               Nothing -> when' canFallBack $ ppValMd' pp o

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1882,9 +1882,7 @@ ppInt64ValMd' canFallBack pp = go
           ValMdValue tv
             | PrimType (Integer _) <- typedType tv
             , ValInteger i <- typedValue tv
-              ->
-                -- 64 bits is the largest Int, so no conversion needed.
-                integer i
+              -> integer i  -- 64 bits is the largest Int, so no conversion needed.
           o@(ValMdDebugInfo (DebugInfoGlobalVariable gv)) ->
             case digvVariable gv of
               Nothing -> when' canFallBack $ ppValMd' pp o

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -174,7 +174,7 @@ import Text.LLVM.Triple.AST (TargetTriple)
 import Text.LLVM.Triple.Print (printTriple)
 
 import Control.Applicative ((<|>))
-import Data.Bits ( shiftL, shiftR, (.|.), (.&.), complement, testBit )
+import Data.Bits ( shiftL, shiftR, (.|.), (.&.) )
 import Data.Bool ( bool )
 import Data.Char (isAlphaNum,isAscii,isDigit,isPrint,ord,toUpper)
 import Data.List ( intersperse, nub )
@@ -184,7 +184,7 @@ import GHC.Float (castDoubleToWord64, castWord32ToFloat, float2Double)
 import Numeric (showHex)
 import Text.PrettyPrint.HughesPJ
 import Data.Int
-import Data.Word (Word16, Word32, Word64)
+import Data.Word (Word16, Word32)
 import Prelude hiding ((<>))
 
 
@@ -1883,15 +1883,8 @@ ppInt64ValMd' canFallBack pp = go
             | PrimType (Integer _) <- typedType tv
             , ValInteger i <- typedValue tv
               ->
-                -- 64 bits is the largest Int, so no conversion needed.  However,
-                -- we intend to be compatible with LLVM's own tooling, and the
-                -- latter will parse these values as signed and will therefore
-                -- fail to parse a value with the high bit set.  Therefore this
-                -- must emit a signed value as well.
-                let v = fromInteger i :: Word64
-                in if testBit v 63
-                   then char '-' <> integer (toInteger $ complement v + 1)
-                   else integer i
+                -- 64 bits is the largest Int, so no conversion needed.
+                integer i
           o@(ValMdDebugInfo (DebugInfoGlobalVariable gv)) ->
             case digvVariable gv of
               Nothing -> when' canFallBack $ ppValMd' pp o


### PR DESCRIPTION
This also updates pretty-printing to output negative values to be compatible with the LLVM tooling which expects to parse a signed 64-bit (instead of an unsigned 64-bit that will later be converted to signed).