### PR TITLE
Fix type pretty-printing for void pointers.

### DIFF
--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -477,7 +477,9 @@ ppType :: Fmt Type
 ppType (PrimType pt)     = ppPrimType pt
 ppType (Alias i)         = ppIdent i
 ppType (Array len ty)    = brackets (integral len <+> char 'x' <+> ppType ty)
-ppType (PtrTo ty)        = ppType ty <> char '*'
+ppType (PtrTo ty)        = ppType ty <> case ty of
+                                          PtrOpaque -> mempty
+                                          _ -> char '*'
 ppType PtrOpaque         = "ptr"
 ppType (Struct ts)       = structBraces (commas (map ppType ts))
 ppType (PackedStruct ts) = angles (structBraces (commas (map ppType ts)))


### PR DESCRIPTION
It's possible (but not wise) to construct a `PtrTo PtrOpaque`, which will incorrectly be emitted with a following asterisk, resulting in something like `store ptr %0, ptr* %2, align 8`, which is invalid because ptr is void and does not allow additional pointer indirection.

This fix detects this construction and avoids the extra indirection, which will be rejected by the LLVM tools.