### PR TITLE
Run the CI on the new 9.12.4 'ghc' release.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,18 +11,10 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04"]
-        ghc: ["9.8.4", "9.10.1"]
+        ghc: ["9.8.4", "9.10.1", "9.12.4"]
         cabal: ["3.14.2.0"]
         test: [true]
         build-targets: ["all"]
-        include:
-          - os: "ubuntu-24.04"
-            ghc: "9.12.2"
-            cabal: "3.14.2.0"
-            test: false
-            # Building the test suite fails on GHC 9.12.2 due to a compiler bug;
-            # see https://gitlab.haskell.org/ghc/ghc/-/issues/25771
-            build-targets: "lib:llvm-pretty"
       fail-fast: false
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }} - Cabal ${{ matrix.cabal }}
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v2


### PR DESCRIPTION
Closes #185.